### PR TITLE
feat: federationMetadata support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/autotelic/mercurius-remote-schema#readme",
   "dependencies": {
+    "@autotelic/graphql-schema-tools": "^0.3.0",
     "@graphql-tools/stitch": "^7.5.2",
     "@graphql-tools/wrap": "^7.0.8",
     "fastify-plugin": "^3.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,8 @@ const {
   sleep,
   createRemoteService,
   createBaseGQLService,
-  createTestExecutor
+  createTestExecutor,
+  createGatewayService
 } = require('./utils')
 
 const plugin = require('..')
@@ -392,4 +393,211 @@ test('automatically refreshes the remote schemas when the pollingInterval plugin
   }
 
   t.same(actual2, expected2)
+})
+
+test('plugin opts - federationMetadata true supports federated services', async (t) => {
+  const federatedSchema = `
+    type Review {
+      author: ID!
+      title: String
+      stars: Int
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      reviews: [Review]
+    }
+`
+
+  const reviews = [
+    {
+      author: '1a',
+      title: 'MovieA',
+      stars: 1
+    },
+    {
+      author: '2b',
+      title: 'MovieB',
+      stars: 5
+    }
+  ]
+  const federatedResolvers = {
+    User: {
+      reviews: ({ id }) => reviews.filter(({ author }) => author === id)
+    }
+  }
+
+  const [federatedService, federatedServicePort] = await createRemoteService(
+    federatedSchema,
+    federatedResolvers,
+    0,
+    { federationMetadata: true }
+  )
+
+  const testSchema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+    }
+  `
+  const testResolvers = {
+    Query: {
+      me: async () => ({ id: '1a' })
+    }
+  }
+
+  t.teardown(async () => {
+    await remoteService.close()
+    await gql.close()
+    await federatedService.close()
+    await gatewayService.close()
+  })
+
+  const [remoteService, remoteServicePort] = await createRemoteService()
+
+  const executor = createTestExecutor(remoteServicePort)
+  const gql = createBaseGQLService(
+    testSchema,
+    testResolvers,
+    { federationMetadata: true }
+  )
+
+  gql.register(plugin, {
+    subschemas: [{ executor }],
+    federationMetadata: true
+  })
+
+  await gql.ready()
+  await gql.listen(0)
+  const { port } = gql.server.address()
+
+  const [gatewayService] = await createGatewayService([
+    {
+      name: 'base',
+      url: `http://localhost:${port}/graphql`
+    },
+    {
+      name: 'user',
+      url: `http://localhost:${federatedServicePort}/graphql`
+    }
+  ])
+
+  const actual = await gql.inject.query(`{
+    _service {
+      sdl
+    }
+  }`)
+
+  const sdl = `type Query {
+  add(x: Int, y: Int): Int
+  me: User
+}
+
+type User @key(fields: "id") {
+  id: ID!
+}
+
+union _Entity = User
+`
+
+  const expected = {
+    data: {
+      _service: {
+        sdl
+      }
+    }
+  }
+
+  t.same(actual, expected)
+
+  const gatewayActual = await gatewayService.inject.query(`{
+    me {
+      id
+      reviews {
+        stars
+        title
+      }
+    }
+  }`)
+
+  const gatewayExpected = {
+    data: {
+      me: {
+        id: '1a',
+        reviews: [
+          {
+            stars: 1,
+            title: 'MovieA'
+          }
+        ]
+      }
+    }
+  }
+
+  t.same(gatewayActual, gatewayExpected)
+})
+
+test('plugin opts - federationMetadata true supports federated services with no _entities resolver defined', async (t) => {
+  const testSchema = `
+    extend type Query {
+      multiply(x: Int, y: Int): Result
+    }
+
+    type Result {
+      result: Int
+    }
+  `
+  const testResolvers = {
+    Query: {
+      multiply: async (_, { x, y }) => ({ result: x * y })
+    }
+  }
+
+  t.teardown(async () => {
+    await remoteService.close()
+    await gql.close()
+    await gatewayService.close()
+  })
+
+  const [remoteService, remoteServicePort] = await createRemoteService()
+
+  const executor = createTestExecutor(remoteServicePort)
+  const gql = createBaseGQLService(
+    testSchema,
+    testResolvers,
+    { federationMetadata: true }
+  )
+
+  gql.register(plugin, {
+    subschemas: [{ executor }],
+    federationMetadata: true
+  })
+
+  await gql.ready()
+  await gql.listen(0)
+  const { port } = gql.server.address()
+
+  const [gatewayService] = await createGatewayService([
+    {
+      name: 'base',
+      url: `http://localhost:${port}/graphql`
+    }
+  ])
+
+  const actual = await gatewayService.inject.query(`{
+    multiply(x: 2 y: 2) {
+      result
+    }
+  }`)
+
+  const expected = {
+    data: {
+      multiply: { result: 4 }
+    }
+  }
+
+  t.same(actual, expected)
 })


### PR DESCRIPTION
This pull requests adds support for adding federation metadata to the graphql
service. If the federationMetadata option is set to `true`, the plugin will
update the _service and _entities resolvers to enable federation of the service